### PR TITLE
Add optional ability create device on server

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Now copy the required files to this service:
  chmod +r ./data/certs/*
 ~~~
 
+You can optionally copy a Foundries.io API token (scope `devices:create`) so
+that devices can be defined/configured before the certificate is returned back
+to the device. This can be used for setting up device-groups and config so
+that a device's first boot will include the proper configuration:
+~~~
+  # echo <TOKEN> > ./data/fio-api-token
+~~~
+
 You can now run this API with:
 ~~~
  $ docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,13 @@ services:
     environment:
       DEVICES_DIR: /devices
       CERTS_DIR: /certs
+      FIO_API_TOKEN: /fio-api-token
+      # if FIO_API_TOKEN is provided, assign devices to a device-group
+      DEVICE_GROUP: ${DEVICE_GROUP-}
     volumes:
       - ${DATA_DIR-./data}/devices:/devices
       - ${DATA_DIR-./data}/certs:/certs:ro
+      - ${DATA_DIR-./data}/fio-api-token:/fio-api-token:ro
     ports:
       - ${API_PORT-80}:8000
     restart: always

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -19,7 +19,7 @@ assert_file local-ca.pem
 assert_file local-ca.key
 assert_file tls-crt
 
-dns=$(openssl x509 -text -noout -in ${CERTS_DIR}/tls-crt | grep DNS | cut -d: -f2)
+dns=$(openssl x509 -text -noout -in ${CERTS_DIR}/tls-crt | grep -o "DNS:[[:print:]]*.ota-lite.foundries.io" | sed -e 's/^DNS://')
 export DEVICE_GATEWAY_SERVER=https://${dns}:8443
 export ROOT_CRT=$(cat ${CERTS_DIR}/factory_ca.pem)
 export CA_CRT=$(cat ${CERTS_DIR}/local-ca.pem)

--- a/fake-lmp-device-register
+++ b/fake-lmp-device-register
@@ -20,9 +20,10 @@ class Options(NamedTuple):
     uuid: str
     name: str
     registration_url: str
+    production: bool
 
 
-def create_key(uuid: str, factory: str) -> Tuple[bytes, bytes]:
+def create_key(uuid: str, factory: str, production: bool) -> Tuple[bytes, bytes]:
     key = subprocess.check_output(
         ["openssl", "ecparam", "-genkey", "-name", "prime256v1"]
     )
@@ -37,11 +38,16 @@ req_extensions = ext
 [dn]
 CN={uuid}
 OU={factory}
-
+""".encode()
+        )
+        if production:
+            cnf.write(b"businessCategory=production\n")
+        cnf.write(
+            b"""
 [ext]
 keyUsage=critical, digitalSignature
 extendedKeyUsage=critical, clientAuth
-""".encode()
+"""
         )
         cnf.flush()
 
@@ -56,7 +62,7 @@ extendedKeyUsage=critical, clientAuth
 
 
 def main(opts: Options):
-    pkey, csr = create_key(opts.uuid, opts.factory)
+    pkey, csr = create_key(opts.uuid, opts.factory, opts.production)
     data = {
         "name": opts.name,
         "uuid": opts.uuid,
@@ -96,10 +102,11 @@ curl --cert client.pem --key pkey.pem --cacert root.crt $*""".encode()
 
 
 def get_parser() -> ArgumentParser:
-    p = ArgumentParser(description="Example client to foundries.io intel esh api")
+    p = ArgumentParser(description="Example client to ease local testing")
     p.add_argument(
         "--factory", "-f", required=True, help="Name of factory to register device in"
     )
+    p.add_argument("--production", action="store_true", help="Make 'production' cert")
     p.add_argument("--sota-dir", "-d", default="/var/sota", help="default=%(default)s")
     p.add_argument("--tags", "-t", default="master", help="default=%(default)s")
     p.add_argument("--apps", "-a")
@@ -134,5 +141,6 @@ if __name__ == "__main__":
         uuid=args.uuid,
         name=args.name,
         registration_url=args.registration_url,
+        production=args.production,
     )
     main(options)

--- a/registration_ref/settings.py
+++ b/registration_ref/settings.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 
 def _env(name: str) -> str:
@@ -38,3 +39,16 @@ class Settings:
     @staticmethod
     def DEVICES_DIR() -> str:
         return _env("DEVICES_DIR")
+
+    @class_property  # type: ignore
+    @staticmethod
+    def DEVICE_GROUP() -> str:
+        return _env("DEVICE_GROUP")
+
+    @class_property  # type: ignore
+    @staticmethod
+    def API_TOKEN_PATH() -> Optional[str]:
+        p = os.environ.get("FIO_API_TOKEN")
+        if p and os.path.isfile(p):
+            return p
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask
 flask_testing
 gunicorn
 mypy
+requests

--- a/requirements.txt.pinned
+++ b/requirements.txt.pinned
@@ -1,11 +1,14 @@
 appdirs==1.4.4
 black==20.8b1
+certifi==2020.12.5
 cffi==1.14.3
+chardet==4.0.0
 click==7.1.2
 cryptography==3.2.1
 Flask==1.1.2
 Flask-Testing==0.8.0
 gunicorn==20.0.4
+idna==2.10
 itsdangerous==1.1.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
@@ -14,8 +17,10 @@ mypy-extensions==0.4.3
 pathspec==0.8.1
 pycparser==2.20
 regex==2020.11.13
+requests==2.25.1
 six==1.15.0
 toml==0.10.2
 typed-ast==1.4.1
 typing-extensions==3.7.4.3
+urllib3==1.26.4
 Werkzeug==1.0.1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -52,6 +52,7 @@ class TestApi(TestCase):
         with TemporaryDirectory() as d:
             with patch("registration_ref.app.Settings") as settings:
                 settings.DEVICES_DIR = d
+                settings.API_TOKEN_PATH = None
                 r = self._sign({"csr": "n/a", "overrides": overrides})
                 with open(os.path.join(d, "uuid")) as f:
                     self.assertEqual("pub", f.read())


### PR DESCRIPTION
This is handy for allowing the manufacturing process to pre-configure
the device. e.g you might do a:

 lmp-device-register --start-daemon=0
 fioconfig check-in  # device now has initial config

 reboot # device is ready for production use

Signed-off-by: Andy Doan <andy@foundries.io>