### PR TITLE
Crypthography expects datetime.utcnow for time fields

### DIFF
--- a/registration_ref/crypto.py
+++ b/registration_ref/crypto.py
@@ -65,8 +65,8 @@ def sign_device_csr(csr: str) -> DeviceInfo:
         .serial_number(int("0x" + uuid.replace("-", ""), 16))
         .issuer_name(ca.subject)
         .public_key(cert.public_key())
-        .not_valid_before(datetime.datetime.now())
-        .not_valid_after(datetime.datetime.now() + datetime.timedelta(days=7300))
+        .not_valid_before(datetime.datetime.utcnow())
+        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=7300))
         .add_extension(
             x509.KeyUsage(
                 digital_signature=True,


### PR DESCRIPTION
Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>