### PR TITLE
doc: avoid an auth at webui if token is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can now run this API with:
 
 From an LmP device:
 ~~~
- $ DEVICE_API=http://<IP of docker-compose host>/sign lmp-device-register
+ $ DEVICE_API=http://<IP of docker-compose host>/sign lmp-device-register [-T <TOKEN>]
 ~~~
 
 # Testing/Troubleshooting


### PR DESCRIPTION
If a user set a token in `./data/fio-api-token` there is no need
in an API request to obtain an oauth token from the backend, a user
can make a direct call to the device registration endpoint via
factory-registration-ref server.

Signed-off-by: Mike Sul <mike.sul@foundries.io>