### PR TITLE
Included chained cert in response

### DIFF
--- a/registration_ref/app.py
+++ b/registration_ref/app.py
@@ -88,6 +88,7 @@ def sign_csr():
                 "root.crt": fields.root_crt,
                 "sota.toml": sota_toml_fmt(overrides, sota_config_dir),
                 "client.pem": fields.client_crt,
+                "client.chained": fields.client_crt + "\n" + Settings.CA_CRT,
             },
         ),
         201,


### PR DESCRIPTION
It can sometimes be useful to know the CA that signed the client
certificate. Our device-gateway doesn't want this and finds the proper
intermediate CA. However, services such as AWS IOT require that the
client present the chained client cert.

This change includes the chained cert so that we get the best of both
worlds. I've named the file client.chained so that lmp-device-register
will *save* the file, but not do anything else special:

 https://github.com/foundriesio/lmp-device-register/blob/b54dfa3469e98334c0bcf0781d7374790ccb77b1/src/main.cpp#L695-L714

Signed-off-by: Andy Doan <andy@foundries.io>