### PR TITLE
app: Don't allow devices to define their device group

### DIFF
--- a/registration_ref/app.py
+++ b/registration_ref/app.py
@@ -72,6 +72,12 @@ def sign_csr():
     sota_config_dir = data.get("sota-config-dir") or "/var/sota"
     name = data.get("name") or None
 
+    if data.get("group"):
+        # Since we run w/o any authentication, allowing devices to determine
+        # their device group is too dangerous to allow by default. We instead
+        # allow a server defined config, Settings.DEVICE_GROUP.
+        abort(400, description="Registration-reference does not support 'group' field")
+
     try:
         fields = sign_device_csr(csr)
     except ValueError as e:


### PR DESCRIPTION
Corresponds to:

 https://github.com/foundriesio/lmp-device-register/pull/31

Signed-off-by: Andy Doan <andy@foundries.io>