### PR TITLE
Chore: support MEDS

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -19,10 +19,11 @@ assert_file local-ca.pem
 assert_file local-ca.key
 assert_file tls-crt
 
-dns=$(openssl x509 -text -noout -in ${CERTS_DIR}/tls-crt | grep -o "DNS:[[:print:]]*.ota-lite.foundries.io" | sed -e 's/^DNS://')
-ostree_hostname=$(openssl x509 -ext subjectAltName -noout -in ${CERTS_DIR}/tls-crt  | grep -o "DNS:[^,]*ostree.foundries.io" | sed -e 's/^DNS://')
-export DEVICE_GATEWAY_SERVER=https://${dns}:8443
-export OSTREE_SERVER=https://${ostree_hostname}:8443
+dns_names=$(openssl x509 -ext subjectAltName -noout -in ${CERTS_DIR}/tls-crt | grep -o 'DNS:[^,]*' | sed -e 's/^DNS://')
+gateway=$(echo ${dns_names} | cut -f1 -d' ')
+ostree=$(echo ${dns_names} | cut -f2 -d' ')
+export DEVICE_GATEWAY_SERVER=https://${gateway}:8443
+export OSTREE_SERVER=https://${ostree}:8443
 export ROOT_CRT=$(cat ${CERTS_DIR}/factory_ca.pem)
 export CA_CRT=$(cat ${CERTS_DIR}/local-ca.pem)
 export CA_KEY=$(cat ${CERTS_DIR}/local-ca.key)


### PR DESCRIPTION
Get rid off hardcoded domain patterns.

The idea is that device gateway is always the first host in the TLS cert, and ostree proxy is always the second one.
It is always that way for certificates generated via FoundriesFactory.