### PR TITLE
fix: fake-lmp-device-register to test the solution locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 
 ### LOCAL FILES
 data/*
+var/*

--- a/fake-lmp-device-register
+++ b/fake-lmp-device-register
@@ -9,6 +9,11 @@ from typing import NamedTuple, Tuple
 from uuid import uuid4
 
 import requests
+import logging
+
+logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                    level=logging.DEBUG)
+log = logging.getLogger(__name__)
 
 
 class Options(NamedTuple):

--- a/fake-lmp-device-register
+++ b/fake-lmp-device-register
@@ -117,7 +117,10 @@ def main(opts: Options):
 
     r = requests.post(opts.registration_url, json=data)
     if r.status_code != 201:
-        sys.exit("ERROR: HTTP_%d: %s" % (r.status_code, r.text))
+        log.error("ERROR: HTTP_%d: %s", r.status_code, r.text)
+        sys.exit(1)
+    else:
+        log.debug("Successfully registered device with status code: %d", r.status_code)
 
     with open(os.path.join(opts.sota_dir, "pkey.pem"), "wb") as f:
         f.write(pkey)

--- a/fake-lmp-device-register
+++ b/fake-lmp-device-register
@@ -29,41 +29,60 @@ class Options(NamedTuple):
 
 
 def create_key(uuid: str, factory: str, production: bool) -> Tuple[bytes, bytes]:
-    key = subprocess.check_output(
-        ["openssl", "ecparam", "-genkey", "-name", "prime256v1"]
-    )
+    try:
+        log.info("Creating key for UUID: %s, Factory: %s", uuid, factory)
 
-    with NamedTemporaryFile() as cnf:
-        cnf.write(
-            f"""[req]
-prompt = no
-distinguished_name = dn
-req_extensions = ext
+        # Create a private key and store it in a temp file
+        with NamedTemporaryFile(delete=False, suffix=".pem") as keyfile:
+            key = subprocess.check_output(["openssl", "ecparam", "-genkey", "-name", "prime256v1"])
+            keyfile.write(key)
+            keyfile_path = keyfile.name
+            keyfile.flush()
 
-[dn]
-CN={uuid}
-OU={factory}
-""".encode()
-        )
-        if production:
-            cnf.write(b"businessCategory=production\n")
-        cnf.write(
-            b"""
-[ext]
-keyUsage=critical, digitalSignature
-extendedKeyUsage=critical, clientAuth
-"""
-        )
-        cnf.flush()
+        # Create a temp config for OpenSSL's CSR generation
+        with NamedTemporaryFile(delete=False) as cnf:
+            cnf.write(f"""[req]
+    prompt = no
+    distinguished_name = dn
+    req_extensions = ext
 
-        r = subprocess.run(
-            ["openssl", "req", "-new", "-config", cnf.name, "-key", "-"],
-            input=key,
-            stdout=subprocess.PIPE,
-        )
-        r.check_returncode()
+    [dn]
+    CN={uuid}
+    OU={factory}
+    """.encode()
+            )
+            if production:
+                cnf.write(b"businessCategory=production\n")
+            cnf.write(
+                b"""
+    [ext]
+    keyUsage=critical, digitalSignature
+    extendedKeyUsage=critical, clientAuth
+    """
+            )
+            cnf.flush()
+            cnf.close()
+
+            # Use OpenSSL to generate a CSR using the private key and config
+            r = subprocess.run(["openssl", "req", "-new", "-config", cnf.name, "-key", keyfile_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            if r.returncode != 0:
+                log.error("Error in running openssl command:")
+                log.error(r.stderr.decode())
+
+                # Clean up temp files in case of errors
+                os.unlink(cnf.name)
+                os.unlink(keyfile_path)
+                raise subprocess.CalledProcessError(r.returncode, r.args)
+
+    except Exception as e:
+        log.error("An error occurred: %s", e)
+    finally:
+        # Let's ensure that temp files are deleted
+        os.unlink(cnf.name)
+        os.unlink(keyfile_path)
 
     return key, r.stdout
+
 
 
 def main(opts: Options):

--- a/fake-lmp-device-register
+++ b/fake-lmp-device-register
@@ -43,7 +43,7 @@ def create_key(uuid: str, factory: str, production: bool, sota_dir: str) -> Tupl
             key_data = keyfile.read()
 
         # Create a temp config for OpenSSL's CSR generation
-        with NamedTemporaryFile(delete=False) as cnf:
+        with NamedTemporaryFile(delete=True) as cnf:
             cnf.write(f"""[req]
     prompt = no
     distinguished_name = dn
@@ -64,7 +64,6 @@ def create_key(uuid: str, factory: str, production: bool, sota_dir: str) -> Tupl
     """
             )
             cnf.flush()
-            cnf.close()
 
             # Use OpenSSL to generate a CSR using the private key and config
             r = subprocess.run(["openssl", "req", "-new", "-config", cnf.name, "-key", keyfile_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -79,9 +78,6 @@ def create_key(uuid: str, factory: str, production: bool, sota_dir: str) -> Tupl
     except Exception as e:
         log.error("An error occurred: %s", e)
         raise
-    finally:
-        # Let's ensure that temp files are deleted
-        os.unlink(cnf.name)
 
     return key_data, r.stdout
 

--- a/fake-lmp-device-register
+++ b/fake-lmp-device-register
@@ -28,16 +28,19 @@ class Options(NamedTuple):
     production: bool
 
 
-def create_key(uuid: str, factory: str, production: bool) -> Tuple[bytes, bytes]:
+def create_key(uuid: str, factory: str, production: bool, sota_dir: str) -> Tuple[bytes, bytes]:
+    # Set path for the private key file
+    keyfile_path = os.path.join(sota_dir, "pkey.pem")
+
     try:
         log.info("Creating key for UUID: %s, Factory: %s", uuid, factory)
 
-        # Create a private key and store it in a temp file
-        with NamedTemporaryFile(delete=False, suffix=".pem") as keyfile:
-            key = subprocess.check_output(["openssl", "ecparam", "-genkey", "-name", "prime256v1"])
-            keyfile.write(key)
-            keyfile_path = keyfile.name
-            keyfile.flush()
+        # Generate a private key into current-dir/var/sota
+        subprocess.check_call(["openssl", "ecparam", "-genkey", "-name", "prime256v1", "-out", keyfile_path])
+
+        # Read the key from the file
+        with open(keyfile_path, "rb") as keyfile:
+            key_data = keyfile.read()
 
         # Create a temp config for OpenSSL's CSR generation
         with NamedTemporaryFile(delete=False) as cnf:
@@ -71,17 +74,16 @@ def create_key(uuid: str, factory: str, production: bool) -> Tuple[bytes, bytes]
 
                 # Clean up temp files in case of errors
                 os.unlink(cnf.name)
-                os.unlink(keyfile_path)
                 raise subprocess.CalledProcessError(r.returncode, r.args)
 
     except Exception as e:
         log.error("An error occurred: %s", e)
+        raise
     finally:
         # Let's ensure that temp files are deleted
         os.unlink(cnf.name)
-        os.unlink(keyfile_path)
 
-    return key, r.stdout
+    return key_data, r.stdout
 
 
 def main(opts: Options):
@@ -91,7 +93,7 @@ def main(opts: Options):
     if not os.path.exists(opts.sota_dir):
         os.makedirs(opts.sota_dir)
 
-    pkey, csr = create_key(opts.uuid, opts.factory, opts.production)
+    pkey, csr = create_key(opts.uuid, opts.factory, opts.production, opts.sota_dir)
 
     # Save the private key into current-dir/var/sota/
     with open(os.path.join(opts.sota_dir, "pkey.pem"), "wb") as f:

--- a/fake-lmp-device-register
+++ b/fake-lmp-device-register
@@ -84,9 +84,19 @@ def create_key(uuid: str, factory: str, production: bool) -> Tuple[bytes, bytes]
     return key, r.stdout
 
 
-
 def main(opts: Options):
+    log.info("Starting main function with options: Factory=%s, SOTA Directory=%s", opts.factory, opts.sota_dir)
+
+    # Ensure the sota directory exists in the current dir
+    if not os.path.exists(opts.sota_dir):
+        os.makedirs(opts.sota_dir)
+
     pkey, csr = create_key(opts.uuid, opts.factory, opts.production)
+
+    # Save the private key into current-dir/var/sota/
+    with open(os.path.join(opts.sota_dir, "pkey.pem"), "wb") as f:
+        f.write(pkey)
+
     data = {
         "name": opts.name,
         "uuid": opts.uuid,
@@ -131,7 +141,7 @@ def get_parser() -> ArgumentParser:
         "--factory", "-f", required=True, help="Name of factory to register device in"
     )
     p.add_argument("--production", action="store_true", help="Make 'production' cert")
-    p.add_argument("--sota-dir", "-d", default="/var/sota", help="default=%(default)s")
+    p.add_argument("--sota-dir", "-d", default=os.path.join(os.getcwd(), "var", "sota"), help="default=%(default)s")
     p.add_argument("--tags", "-t", default="master", help="default=%(default)s")
     p.add_argument("--apps", "-a")
     p.add_argument(


### PR DESCRIPTION
**Description**

Fix the fake client to emulate the device registration and generate the /var/sota/ dir with the files in the current directory when we are using it to do the tests.

See:

```
$ python3 fake-lmp-device-register --registration-url "http://localhost:80/sign" --factory fioed-camila-sample

2023-11-02 09:10:17,901 - __main__ - INFO - Starting main function with options: Factory=fioed-camila-sample, SOTA Directory=/Users/camilamacedo/go/src/github.com/foundriesio/factory-registration-ref/var/sota
2023-11-02 09:10:17,901 - __main__ - INFO - Creating key for UUID: dc4d274b-80ce-471b-87a2-a50a31b35fca, Factory: fioed-camila-sample
2023-11-02 09:10:17,916 - urllib3.connectionpool - DEBUG - Starting new HTTP connection (1): localhost:80
2023-11-02 09:10:18,185 - urllib3.connectionpool - DEBUG - http://localhost:80 "POST /sign HTTP/1.1" 201 4057
2023-11-02 09:10:18,185 - __main__ - DEBUG - Successfully registered device with status code: 201
```

Signed-off-by: Camila Macedo <camila.macedo@foundries.io>