### PR TITLE
fix: fake-lmp-device-register to test the solution locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 
 ### LOCAL FILES
 data/*
+var/*

--- a/fake-lmp-device-register
+++ b/fake-lmp-device-register
@@ -23,9 +23,11 @@ class Options(NamedTuple):
     production: bool
 
 
-def create_key(uuid: str, factory: str, production: bool) -> Tuple[bytes, bytes]:
-    key = subprocess.check_output(
-        ["openssl", "ecparam", "-genkey", "-name", "prime256v1"]
+def create_key(uuid: str, factory: str, production: bool, sota_dir: str) -> bytes:
+    keyfile_path = os.path.join(sota_dir, "pkey.pem")
+
+    subprocess.check_call(
+        ["openssl", "ecparam", "-genkey", "-name", "prime256v1", "-out", keyfile_path]
     )
 
     with NamedTemporaryFile() as cnf:
@@ -52,17 +54,17 @@ extendedKeyUsage=critical, clientAuth
         cnf.flush()
 
         r = subprocess.run(
-            ["openssl", "req", "-new", "-config", cnf.name, "-key", "-"],
-            input=key,
+            ["openssl", "req", "-new", "-config", cnf.name, "-key", keyfile_path],
             stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
         r.check_returncode()
 
-    return key, r.stdout
+    return r.stdout
 
 
 def main(opts: Options):
-    pkey, csr = create_key(opts.uuid, opts.factory, opts.production)
+    csr = create_key(opts.uuid, opts.factory, opts.production, opts.sota_dir)
     data = {
         "name": opts.name,
         "uuid": opts.uuid,
@@ -85,9 +87,6 @@ def main(opts: Options):
     if r.status_code != 201:
         sys.exit("ERROR: HTTP_%d: %s" % (r.status_code, r.text))
 
-    with open(os.path.join(opts.sota_dir, "pkey.pem"), "wb") as f:
-        f.write(pkey)
-
     for k, v in r.json().items():
         with open(os.path.join(opts.sota_dir, k), mode="w") as f:  # type: ignore
             f.write(v)
@@ -107,7 +106,7 @@ def get_parser() -> ArgumentParser:
         "--factory", "-f", required=True, help="Name of factory to register device in"
     )
     p.add_argument("--production", action="store_true", help="Make 'production' cert")
-    p.add_argument("--sota-dir", "-d", default="/var/sota", help="default=%(default)s")
+    p.add_argument("--sota-dir", "-d", default=os.path.join(os.getcwd(), "var", "sota"), help="default=%(default)s")
     p.add_argument("--tags", "-t", default="master", help="default=%(default)s")
     p.add_argument("--apps", "-a")
     p.add_argument(


### PR DESCRIPTION
**Description**

Fix the fake client to emulate the device registration and set as default the /var/sota/ dir in the current directory.

Signed-off-by: Camila Macedo <camila.macedo@foundries.io>