### PR TITLE
chore: add logs to allow debug and follow up fake-register call

### DIFF
--- a/fake-lmp-device-register
+++ b/fake-lmp-device-register
@@ -9,6 +9,11 @@ from typing import NamedTuple, Tuple
 from uuid import uuid4
 
 import requests
+import logging
+
+logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                    level=logging.DEBUG)
+log = logging.getLogger(__name__)
 
 
 class Options(NamedTuple):
@@ -24,12 +29,15 @@ class Options(NamedTuple):
 
 
 def create_key(uuid: str, factory: str, production: bool, sota_dir: str) -> bytes:
+    log.info("Setting path for the private key file: %s", sota_dir)
     keyfile_path = os.path.join(sota_dir, "pkey.pem")
 
+    log.info("Creating key for UUID: %s, Factory: %s", uuid, factory)
     subprocess.check_call(
         ["openssl", "ecparam", "-genkey", "-name", "prime256v1", "-out", keyfile_path]
     )
 
+    log.info("Creating CSR for UUID: %s, Factory: %s", uuid, factory)
     with NamedTemporaryFile() as cnf:
         cnf.write(
             f"""[req]
@@ -56,7 +64,6 @@ extendedKeyUsage=critical, clientAuth
         r = subprocess.run(
             ["openssl", "req", "-new", "-config", cnf.name, "-key", keyfile_path],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
         )
         r.check_returncode()
 
@@ -64,6 +71,7 @@ extendedKeyUsage=critical, clientAuth
 
 
 def main(opts: Options):
+    log.info("Creating key and CSR")
     csr = create_key(opts.uuid, opts.factory, opts.production, opts.sota_dir)
     data = {
         "name": opts.name,
@@ -84,9 +92,9 @@ def main(opts: Options):
         data["overrides"]["pacman"]["compose_apps"] = '"' + opts.apps + '"'  # type: ignore
 
     r = requests.post(opts.registration_url, json=data)
-    if r.status_code != 201:
-        sys.exit("ERROR: HTTP_%d: %s" % (r.status_code, r.text))
-
+    r.raise_for_status()
+    log.debug("Successfully registered device with status code: %d", r.status_code)
+        
     for k, v in r.json().items():
         with open(os.path.join(opts.sota_dir, k), mode="w") as f:  # type: ignore
             f.write(v)


### PR DESCRIPTION
**Description**
Chore: add logs to allow debug and follow up fake-register call
Example:

```sh
$ python3 fake-lmp-device-register --registration-url "http://localhost:80/sign" --factory fioed-camila-sample
2023-11-06 06:24:49,855 - __main__ - INFO - Creating key and CSR
2023-11-06 06:24:49,855 - __main__ - INFO - Setting path for the private key file: /Users/camilamacedo/go/src/github.com/foundriesio/factory-registration-ref/var/sota
2023-11-06 06:24:49,855 - __main__ - INFO - Creating key for UUID: 50702700-6006-4652-a050-bf6c5dc41c01, Factory: fioed-camila-sample
2023-11-06 06:24:49,860 - __main__ - INFO - Creating CSR for UUID: 50702700-6006-4652-a050-bf6c5dc41c01, Factory: fioed-camila-sample
2023-11-06 06:24:49,860 - __main__ - INFO - Running openssl req
2023-11-06 06:24:49,865 - __main__ - INFO - Registering device
2023-11-06 06:24:49,869 - urllib3.connectionpool - DEBUG - Starting new HTTP connection (1): localhost:80
2023-11-06 06:24:52,874 - urllib3.connectionpool - DEBUG - http://localhost:80 "POST /sign HTTP/1.1" 500 290
2023-11-06 06:24:52,875 - __main__ - ERROR - ERROR: HTTP_500: <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>500 Internal Server Error</title>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.</p>


```

PS: This PR is related ONLY to its latest commit. We need to merge the fix #18 first:  