### PR TITLE
Fix: add Authority Key Id extension to generated device certificates

### DIFF
--- a/registration_ref/crypto.py
+++ b/registration_ref/crypto.py
@@ -85,6 +85,10 @@ def sign_device_csr(csr: str) -> DeviceInfo:
             x509.ExtendedKeyUsage([x509.ExtendedKeyUsageOID.CLIENT_AUTH]),
             critical=True,
         )
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(pk.public_key()),
+            critical=False,
+        )
         .sign(pk, SHA256(), default_backend())
     )
     signed_bytes = signed.public_bytes(encoding=Encoding.PEM)


### PR DESCRIPTION
This is now kind of required by the strict X.509 certificate validation. So, we need our reference registration server respect it as a good guidance.